### PR TITLE
 페이지 전환 시, scroll 상단으로 이동

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import Admins from './pages/Admins';
 import { Route } from 'react-router-dom';
 import { dbCtrl, firebase, fbdb } from './database/DBCtrl';
 import isMobile from './method/ismobile';
+import ScrollTop from './components/ScrollTop';
 
 // 임시로 전역 객체로 등록한 거임!!
 window.firebase = firebase;
@@ -37,13 +38,15 @@ function App() {
                 <>
                     <Nav current="mail"></Nav>
                     <Wrapper>
-                        <Route path="/" component={Main} exact />
-                        <Route path="/recruit" component={Recruit} />
-                        <Route path="/faq/:id" component={FAQ} />
-                        <Route path="/login" component={Login} />
-                        <Route path="/apply" component={Apply} />
-                        <Route path="/cardpage/:title" component={CardPage} />
-                        <Route path="/admins" component={Admins} />
+                        <ScrollTop>
+                            <Route path="/" component={Main} exact />
+                            <Route path="/recruit" component={Recruit} />
+                            <Route path="/faq/:id" component={FAQ} />
+                            <Route path="/login" component={Login} />
+                            <Route path="/apply" component={Apply} />
+                            <Route path="/cardpage/:title" component={CardPage} />
+                            <Route path="/admins" component={Admins} />
+                        </ScrollTop>
                     </Wrapper>
                     <Footer></Footer>
                 </>

--- a/src/components/ScrollTop.js
+++ b/src/components/ScrollTop.js
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+import Main from '../pages/Main';
+
+const ScrollToTop = ({ children, location: { pathname } }) => {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+    return children;
+};
+export default withRouter(ScrollToTop);

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -13,9 +13,16 @@ import useScrollTrigger from '@material-ui/core/useScrollTrigger';
 const useStyles = makeStyles(theme => ({
     root: {
         position: 'fixed',
-        bottom: theme.spacing(2),
-        right: theme.spacing(2),
-        color: 'blue',
+        bottom: theme.spacing(4),
+        right: theme.spacing(4),
+        '& .MuiFab-root': {
+            color: 'white',
+            backgroundColor: '#ff6d70',
+        },
+        '& .MuiFab-sizeSmall': {
+            width: '46px',
+            height: '46px',
+        },
     },
 }));
 
@@ -38,6 +45,13 @@ function ScrollTop(props) {
     );
 }
 
+const scrollTo = e => {
+    window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+    });
+};
+
 function Main(props) {
     return (
         <>
@@ -53,7 +67,7 @@ function Main(props) {
             </Element>
 
             <ScrollTop>
-                <Fab color="secondary" size="small" aria-label="scroll back to top">
+                <Fab size="small" aria-label="scroll back to top" onClick={scrollTo}>
                     <KeyboardArrowUpIcon />
                 </Fab>
             </ScrollTop>

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -4,8 +4,41 @@ import Section2 from '../components/Section2';
 import Section3 from '../components/Section3';
 import Section4 from '../components/Section4';
 import { Element } from 'react-scroll';
+import { makeStyles } from '@material-ui/core/styles';
+import Fab from '@material-ui/core/Fab';
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
+import Zoom from '@material-ui/core/Zoom';
+import useScrollTrigger from '@material-ui/core/useScrollTrigger';
 
-function Main() {
+const useStyles = makeStyles(theme => ({
+    root: {
+        position: 'fixed',
+        bottom: theme.spacing(2),
+        right: theme.spacing(2),
+        color: 'blue',
+    },
+}));
+
+function ScrollTop(props) {
+    const { children, window } = props;
+    const classes = useStyles();
+
+    const trigger = useScrollTrigger({
+        target: window ? window() : undefined,
+        disableHysteresis: true,
+        threshold: 100,
+    });
+
+    return (
+        <Zoom in={trigger}>
+            <div role="presentation" className={classes.root}>
+                {children}
+            </div>
+        </Zoom>
+    );
+}
+
+function Main(props) {
     return (
         <>
             <Section1></Section1>
@@ -18,6 +51,12 @@ function Main() {
             <Element name="test3">
                 <Section4></Section4>
             </Element>
+
+            <ScrollTop>
+                <Fab color="secondary" size="small" aria-label="scroll back to top">
+                    <KeyboardArrowUpIcon />
+                </Fab>
+            </ScrollTop>
         </>
     );
 }

--- a/src/pages/Recruit.js
+++ b/src/pages/Recruit.js
@@ -101,7 +101,7 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-function Recruit() {
+function Recruit(props) {
     const classes = useStyles();
     const [toApply, gotoApply] = useState(false);
 


### PR DESCRIPTION
#42 에 따라서 페이지 이동될 때마다, scroll이 중간에 머무르는 UX문제 개선하기 위해 **./componets/ScrollTo** 컴포넌트 생성하였습니다. 

### Major fix
App.js 에서 모든 페이지를 ScrollTop컴포넌트로 감싼 뒤,  useEffect hooks를 이용하여 페이지 컴포넌트들이 **마운트**(컴포넌트 재성성)될 때마다 window.scrollTo(0,0) 이 되도록하였습니다. 

### Minor fix 

1. 프로젝트 카드 뷰 more 버튼 수정
2. 메인페이지 한정 **TOP버튼** 생성 
